### PR TITLE
🐛 fix #10

### DIFF
--- a/app/Http/Controllers/api/v1/customer/CustomerController.php
+++ b/app/Http/Controllers/api/v1/customer/CustomerController.php
@@ -38,7 +38,8 @@ class CustomerController extends Controller
         $validation = $this->validateCustomer($customerData->all());
         if ($validation !== true) return $validation;
 
-        $customer = Customer::create($customerData->toArray());
+        $customerCreated = Customer::create($customerData->toArray());
+        $customer = Customer::find($customerCreated->id);
 
         return response(['customer' => $customer], config('httpcodes.CREATED'));
     }
@@ -60,20 +61,20 @@ class CustomerController extends Controller
     private function validateCustomer($data) {
         $validation = Validator::make($data, [
             'name' => 'required|string',
-            'siren' => 'optional|string|digits:9',
-            'logo' => 'optional|file|image|mimes:jpeg,png',
-            'address_street_number' => 'optional|numeric|min:0',
-            'address_street_name' => 'optional|string',
-            'address_zip_code' => 'optional|numeric|min:5',
-            'address_city' => 'optional|string',
-            'address_country' => 'optional|string',
-            'address_billing' => 'optional|string',
-            'tva_number' => 'optional|string|min:13|max:13',
-            'website' => 'optional|string|url',
-            'source' => 'optional|string',
-            'referent_name' => 'optional|string',
-            'referent_email' => 'optional|string|email',
-            'referent_number' => 'optional|string|min:12|max:12',
+            'siren' => 'nullable|string|digits:9',
+            'logo' => 'nullable|file|image|mimes:jpeg,png',
+            'address_street_number' => 'nullable|string',
+            'address_street_name' => 'nullable|string',
+            'address_zip_code' => 'nullable|string|digits:5',
+            'address_city' => 'nullable|string',
+            'address_country' => 'nullable|string',
+            'address_billing' => 'nullable|string',
+            'tva_number' => 'nullable|string|min:13|max:13',
+            'website' => 'nullable|string|url',
+            'source' => 'nullable|string',
+            'referent_name' => 'nullable|string',
+            'referent_email' => 'nullable|string|email',
+            'referent_number' => 'nullable|string|min:12|max:12',
         ]);
         if ($validation->fails())
             return response(['errors' => $validation->messages()], config('httpcodes.UNPROCESSABLE_ENTITY'));


### PR DESCRIPTION
# Description

Updated validation patterns to change `optional` flag to `nullable`.

Fixes #10

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

1. Go on PostMan or any REST client
2. Hit http://backup-organizer.localhost/api/v1/customer with `name` field and an optional flag like `website`
3. Now, Laravel does not print any errors

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
